### PR TITLE
Improve batchConv type checking

### DIFF
--- a/typings.d.ts
+++ b/typings.d.ts
@@ -20,6 +20,9 @@ declare module 'ext.gadget.HanAssist' {
    * @param locale locale, defaults to `wgUserLanguage`
    * @returns converted candidates dictionary
    */
+  export function batchConv<T extends string>(
+    candidatesDict: Record<T, string | Candidates>, locale?: string,
+  ): Record<T, string>;
   export function batchConv(
     candidatesDict: Record<string, string | Candidates>, locale?: string,
   ): Record<string, string>;

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -23,9 +23,6 @@ declare module 'ext.gadget.HanAssist' {
   export function batchConv<T extends string>(
     candidatesDict: Record<T, string | Candidates>, locale?: string,
   ): Record<T, string>;
-  export function batchConv(
-    candidatesDict: Record<string, string | Candidates>, locale?: string,
-  ): Record<string, string>;
 
   global {
     /** @deprecated Use `HanAssist.conv` instead */


### PR DESCRIPTION
Improve batchConv type checking.

Before:
```typescript
const messages = HanAssist.batchConv({
    name: { hans: '123', hant: '456' },
    hello: 'world',
});

messages; // Record<string, string>
```

After:
```typescript
const messages = HanAssist.batchConv({
    name: { hans: '123', hant: '456' },
    hello: 'world',
});

messages; // Record<'name' | 'hello', string>
```
